### PR TITLE
Ensure `site-packages` is created

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 class python {
   include boxen::config
   include homebrew
+  include homebrew::config
   include xquartz
 
   homebrew::formula { 'python':
@@ -15,6 +16,13 @@ class python {
   package { 'boxen/brews/python':
     ensure  => '2.7.3-boxen1',
     require => Class['xquartz']
+  }
+
+  file { "${homebrew::config::installdir}/lib/python2.7/site-packages":
+    force   => true,
+    ensure  => link,
+    target  => "${homebrew::config::installdir}/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages",
+    require => Package['boxen/brews/python']
   }
 
   file { "${boxen::config::envdir}/python.sh":


### PR DESCRIPTION
In the pre-refactored version of puppet-python, the site-packages was never symlinked properly. Because of that, the installation of `distribute` and `pip` failed. 

This pull ensures that the symlink exists.

(Note: This may require a reinstall of `python-pip` and `python-distribute`. Not sure how to handle that in the manifest.)
