### PR TITLE
Added environment to requirements type -> enables compilation of cx_Oracle

### DIFF
--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -16,7 +16,7 @@ define python::requirements (
   $virtualenv   = undef,
   $upgrade      = false,
   $proxy        = false,
-  $environment  = undef      
+  $environment  = undef
 ) {
   require python
 


### PR DESCRIPTION
$environment is passed to the exec pip command to allow a user to
set environment variables required to compile certain packages.
One example is the cx_Oracle package which requires environment
variables to complile
