### PR TITLE
Fix directory creation failure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class python {
   }
 
   file {
-    "${homebrew::config::installdir}/lib/python2.7":
+    ["${homebrew::config::installdir}/lib", "${homebrew::config::installdir}/lib/python2.7"]:
       ensure => directory ;
     "${homebrew::config::installdir}/lib/python2.7/site-packages":
       ensure  => link,


### PR DESCRIPTION
I installed this module on a fresh boxen install, and /opt/boxen/homebrew/lib does not exist.  This rewrite should ensure its creation if it is not already there.

The original error message was:

```
Error: Cannot create /opt/boxen/homebrew/lib/python2.7; parent directory /opt/boxen/homebrew/lib does not exist
Error: /Stage[main]/Python/File[/opt/boxen/homebrew/lib/python2.7]/ensure: change from absent to directory failed: Cannot create /opt/boxen/homebrew/lib/python2.7; parent directory /opt/boxen/homebrew/lib does not exist
```
