### PR TITLE
Removed share/python from PATH to fix brew doctor

### DIFF
--- a/files/python.sh
+++ b/files/python.sh
@@ -1,1 +1,0 @@
-export PATH=$BOXEN_HOME/homebrew/share/python:$PATH


### PR DESCRIPTION
Was getting the following warning from `brew doctor`:

```
Warning: /opt/boxen/homebrew/share/python is not needed in PATH.
Formerly homebrew put Python scripts you installed via `pip` or `pip3`
(or `easy_install`) into that directory above but now it can be removed
from your PATH variable.
Python scripts will now install into /opt/boxen/homebrew/bin.
You can delete anything, except 'Extras', from the /opt/boxen/homebrew/share/python
(and /opt/boxen/homebrew/share/python3) dir and install affected
Python packages anew with `pip install --upgrade`.
```

This PR clears out the contents of `python.sh` but does not remove it in case other env variables need to be set in the future.
