### PR TITLE
virtaulenvwrapper.sh path fix

### DIFF
--- a/templates/python_venvwrapper.sh.erb
+++ b/templates/python_venvwrapper.sh.erb
@@ -1,2 +1,2 @@
-source $BOXEN_HOME/homebrew/share/python/virtualenvwrapper.sh
+source $BOXEN_HOME/homebrew/bin/virtualenvwrapper.sh
 export WORKON_HOME=<%= scope.lookupvar "python::config::venv_home" %>


### PR DESCRIPTION
The virtualenvwrapper is installed into the global venv environment. This is set to $BOXEN_HOME/homebrew. The install puts the script into the bin directory. This patches the path... let me know if there is a better approach.