### PR TITLE
Fix location of virtualenvwrapper.sh

### DIFF
--- a/templates/python_venvwrapper.sh.erb
+++ b/templates/python_venvwrapper.sh.erb
@@ -1,2 +1,2 @@
-source $BOXEN_HOME/homebrew/share/python/virtualenvwrapper.sh
+source $BOXEN_HOME/homebrew/bin/virtualenvwrapper.sh
 export WORKON_HOME=<%= scope.lookupvar "python::config::venv_home" %>


### PR DESCRIPTION
Either I'm doing something wrong, or the template is broken :-). But for me, the pip installs the virtualenvwrapper.sh script in ..../homebrew/bin, not in ..../homebrew/shared/python. 