### PR TITLE
Newest version of puppet homebrew installs homebrew in a different directory

### DIFF
--- a/templates/python_venvwrapper.sh.erb
+++ b/templates/python_venvwrapper.sh.erb
@@ -1,2 +1,8 @@
-source $BOXEN_HOME/homebrew/bin/virtualenvwrapper.sh
+if [ -d "$BOXEN_HOME/homebrew" ] 
+then
+  BREW_HOME=$BOXEN_HOME/homebrew/bin
+else
+  BREW_HOME=/usr/local/bin
+fi
+source $BREW_HOME/virtualenvwrapper.sh
 export WORKON_HOME=<%= scope.lookupvar "python::config::venv_home" %>


### PR DESCRIPTION
Since https://github.com/boxen/puppet-homebrew/commit/d49adf31508a3a218c2da5a4b42ba343e6183200 homebrew is now installed in a different directory. This PR looks for homebrew in the new directory if it is not available in the old one.
